### PR TITLE
Update apps to .NET 7 and to the latest OTEL versions

### DIFF
--- a/App1.WebApi/App1.WebApi.csproj
+++ b/App1.WebApi/App1.WebApi.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
   </ItemGroup>
 
 

--- a/App1.WebApi/Dockerfile
+++ b/App1.WebApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
 WORKDIR /app
 
 # Set intermediate stage as build
@@ -14,7 +14,7 @@ RUN dotnet publish src/*.csproj -c Release -o /app/publish
 
 
 # Build runtime imagedock
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
 WORKDIR /app
 COPY --from=build-env /app/publish .
 ENTRYPOINT ["dotnet", "App1.WebApi.dll"]

--- a/App1.WebApi/Startup.cs
+++ b/App1.WebApi/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -27,17 +28,17 @@ namespace App1.WebApi
         {
             services.AddControllers();
             services.AddHttpClient();
-            services.AddOpenTelemetryTracing(builder =>
+            services.AddOpenTelemetry().WithTracing(builder =>
             {
                 builder.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
                     .AddSource(nameof(PublishMessageController))
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("App1"))
-                    .AddJaegerExporter(opts =>
+                    .AddOtlpExporter(opts =>
                     {
-                        opts.AgentHost = Configuration["Jaeger:AgentHost"];
-                        opts.AgentPort = Convert.ToInt32(Configuration["Jaeger:AgentPort"]);
-                        opts.ExportProcessorType = ExportProcessorType.Simple;
+                        opts.Endpoint =
+                            new Uri(
+                                $"{Configuration["Jaeger:Protocol"]}://{Configuration["Jaeger:Host"]}:{Configuration["Jaeger:Port"]}");
                     });
             });
         }

--- a/App1.WebApi/appsettings.json
+++ b/App1.WebApi/appsettings.json
@@ -8,9 +8,9 @@
   },
   "AllowedHosts": "*",
   "Jaeger": {
-    "ServiceName": "jaeger",
-    "AgentHost": "localhost",
-    "AgentPort": 6831
+    "Protocol": "http",
+    "Host": "localhost",
+    "Port": 4317
   },
   "RabbitMq": {
     "Host": "localhost"

--- a/App2.RabbitConsumer.Console/App2.RabbitConsumer.Console.csproj
+++ b/App2.RabbitConsumer.Console/App2.RabbitConsumer.Console.csproj
@@ -2,23 +2,23 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/App2.RabbitConsumer.Console/Dockerfile
+++ b/App2.RabbitConsumer.Console/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
 WORKDIR /app
 
 # Set intermediate stage as build
@@ -14,7 +14,7 @@ RUN dotnet publish src/*.csproj -c Release -o /app/publish
 
 
 # Build runtime imagedock
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
 WORKDIR /app
 COPY --from=build-env /app/publish .
 COPY wait.sh .

--- a/App2.RabbitConsumer.Console/Program.cs
+++ b/App2.RabbitConsumer.Console/Program.cs
@@ -176,11 +176,11 @@ namespace App2.RabbitConsumer.Console
                 .AddHttpClientInstrumentation()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("App2"))
                 .AddSource(nameof(Program))
-                .AddJaegerExporter(opts =>
+                .AddOtlpExporter(opts =>
                 {
-                    opts.AgentHost = _configuration["Jaeger:AgentHost"];
-                    opts.AgentPort = Convert.ToInt32(_configuration["Jaeger:AgentPort"]);
-                    opts.ExportProcessorType = ExportProcessorType.Simple;
+                    opts.Endpoint =
+                        new Uri(
+                            $"{_configuration["Jaeger:Protocol"]}://{_configuration["Jaeger:Host"]}:{_configuration["Jaeger:Port"]}");
                 })
                 .Build();
         }

--- a/App2.RabbitConsumer.Console/appsettings.json
+++ b/App2.RabbitConsumer.Console/appsettings.json
@@ -1,8 +1,8 @@
 {
   "Jaeger": {
-    "ServiceName": "jaeger",
-    "AgentHost": "localhost",
-    "AgentPort": 6831
+    "Protocol": "http",
+    "Host": "localhost",
+    "Port": 4317
   },
   "RabbitMq": {
     "Host": "localhost"

--- a/App3.WebApi/App3.WebApi.csproj
+++ b/App3.WebApi/App3.WebApi.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc8" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.5.1-beta.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.11" />
   </ItemGroup>
 
 

--- a/App3.WebApi/Dockerfile
+++ b/App3.WebApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
 WORKDIR /app
 
 # Set intermediate stage as build
@@ -14,7 +14,7 @@ RUN dotnet publish src/*.csproj -c Release -o /app/publish
 
 
 # Build runtime imagedock
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
 WORKDIR /app
 COPY --from=build-env /app/publish .
 ENTRYPOINT ["dotnet", "App3.WebApi.dll"]

--- a/App3.WebApi/appsettings.json
+++ b/App3.WebApi/appsettings.json
@@ -8,9 +8,9 @@
   },
   "AllowedHosts": "*",
   "Jaeger": {
-    "ServiceName": "jaeger",
-    "AgentHost": "localhost",
-    "AgentPort": 6831
+    "Protocol": "http",
+    "Host": "localhost",
+    "Port": 4317
   },
   "RabbitMq": {
     "Host": "localhost"

--- a/App4.RabbitConsumer.HostedService/App4.RabbitConsumer.HostedService.csproj
+++ b/App4.RabbitConsumer.HostedService/App4.RabbitConsumer.HostedService.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <UserSecretsId>dotnet-App4.RabbitConsumer.HostedService-B761B03A-E533-4C9A-8E07-20A1A7080F05</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc8" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.10" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.11" />
   </ItemGroup>
 </Project>

--- a/App4.RabbitConsumer.HostedService/Dockerfile
+++ b/App4.RabbitConsumer.HostedService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
 WORKDIR /app
 
 # Set intermediate stage as build
@@ -14,7 +14,7 @@ RUN dotnet publish src/*.csproj -c Release -o /app/publish
 
 
 # Build runtime imagedock
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim
 WORKDIR /app
 COPY --from=build-env /app/publish .
 COPY wait.sh .

--- a/App4.RabbitConsumer.HostedService/appsettings.json
+++ b/App4.RabbitConsumer.HostedService/appsettings.json
@@ -7,15 +7,15 @@
     }
   },
   "Jaeger": {
-    "ServiceName": "jaeger",
-    "AgentHost": "localhost",
-    "AgentPort": 6831
+    "Protocol": "http",
+    "Host": "localhost",
+    "Port": 4317
   },
   "Redis": {
     "Host": "localhost",
     "Port": "6379"
   },
   "RabbitMq": {
-    "Host":  "localhost"
-  } 
+    "Host": "localhost"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ The repository contains the following applications:
 
 ![Alt Text](https://github.com/karlospn/opentelemetry-tracing-demo/blob/master/docs/components-diagram.png)
 
-- **App1.WebApi** is a **NET6 Web API** with 2 endpoints.
+- **App1.WebApi** is a **NET7 Web API** with 2 endpoints.
     - The **/http** endpoint makes an HTTP request to the App2 _"/dummy"_ endpoint.
     - The **/publish-message** endpoint queues a message into a Rabbit queue named _"sample"_.
     
-- **App2.RabbitConsumer.Console** is a **NET6 console** application. 
+- **App2.RabbitConsumer.Console** is a **NET7 console** application. 
   - Dequeues messages from the Rabbit _"sample"_ queue and makes a HTTP request to the **App3** _"/sql-to-event"_ endpoint with the content of the message.
 
-- **App3.WebApi** is a **NET6 Web API** with 2 endpoints
+- **App3.WebApi** is a **NET7 Web API** with 2 endpoints
     - The **/dummy** endpoint returns a fixed _"Ok"_ response.
     - The **/sql-to-event** endpoint receives a message via HTTP POST, stores it in a MSSQL Server and afterwards publishes the message as an event into a RabbitMq queue named _"sample_2"_.
 
-- **App4.RabbitConsumer.HostedService** is a **NET6 Worker Service**.
+- **App4.RabbitConsumer.HostedService** is a **NET7 Worker Service**.
   - A Hosted Service reads the messages from the Rabbitmq _"sample_2"_ queue and stores it into a Redis cache database.
 
 # OpenTelemetry .NET Client
@@ -26,13 +26,13 @@ The repository contains the following applications:
 The apps are using the following package versions:
 
 ```xml
-<PackageReference Include="OpenTelemetry" Version="1.2.0-rc1" />
-<PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.2.0-rc1" />
-<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc8" />
-<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc8" />
-<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc8" />
-<PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc8" />
-<PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc8" />
+  <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+  <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+  <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+  <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+  <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.5.1-beta.1" />
+  <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.10" />
 ```
 
 # External Dependencies
@@ -51,12 +51,50 @@ There is a **little caveat in the docker-compose**:
 That's a problem because both App3 and App4 need to wait for the rabbitMq container to be ready. To avoid this problem the docker-compose is overwriting the "entrypoint" for both apps and executing a shell script that makes both apps sleep 30 seconds before starting up.
 
 
-If you don't want to use the compose file you can use docker to start the dependencies manually, you can ran the following commands:
+If you **don't want to use the docker-compose file**, you can use docker to start the dependencies manually, you can ran the following commands:
 
-- _docker run -d --name jaeger -e COLLECTOR_ZIPKIN_HTTP_PORT=19411 -p 5775:5775/udp -p 6831:6831/udp  -p 6832:6832/udp  -p 5778:5778   -p 16686:16686  -p 14268:14268  -p 19411:19411   jaegertracing/all-in-one_
-- _docker run -d --hostname my-rabbit --name some-rabbit -p 8082:15672 -p 5672:5672 rabbitmq:3.6.15-management_
-- _docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Pass@Word1" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04_
-- _docker run -d --name some-redis -p "6379:6379" redis:6.2.1_
+- Run jaeger image:
+```shell
+docker run -d --name jaeger \
+  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
+  -e COLLECTOR_OTLP_ENABLED=true \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 14250:14250 \
+  -p 14268:14268 \
+  -p 14269:14269 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:latest
+```
+
+- Run rabbitmq image:
+
+```shell
+docker run -d --name some-rabbit \
+  -p 15672:15672 \
+  -p 5672:5672 \
+  rabbitmq:3.12-management
+````
+- Run MSSQL Server
+
+```shell
+docker run -e "ACCEPT_EULA=Y" \
+  -e "SA_PASSWORD=Pass@Word1" \
+  -p 1433:1433 \
+  -d mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04
+````
+
+- Run Redis
+
+```shell
+docker run -d --name some-redis \
+  -p "6379:6379" \
+  redis:7.2.1
+````
 
 
 # Output
@@ -64,3 +102,13 @@ If you don't want to use the compose file you can use docker to start the depend
 If you open jaeger you are going to see something like this
 
 ![Alt Text](https://github.com/karlospn/opentelemetry-tracing-demo/blob/master/docs/jaeger.png)
+
+# Changelog
+
+### **09/23/2023**
+- Update apps to .NET 7.
+- Update OpenTelemetry packages to the latest version.
+- Fix breaking changes on the apps due to the OpenTeleetry packages version upgrade.
+- Removed the ``OpenTelemetry.Exporter.Jaeger`` NuGet package from the apps because it has been deprecated. It has been replaced by the ``OpenTelemetry.Exporter.OpenTelemetryProtocol`` package.
+- Update the ``RabbitMQ.Client`` NuGet package to the latest version.
+- Update the ``dockerfile-compose`` file to use the newest image versions of rabbitmq, redis and jaeger. Also the jaeger image is configured so can it can receive OpenTelemetry trace data via the OpenTelemetry Protocol.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Introduction
+# **Introduction**
 This repository contains an example about how to use opentelemetry for tracing when we have a bunch of distributed applications
 
-# Content
+# **Content**
 
 The repository contains the following applications:
 
@@ -21,7 +21,7 @@ The repository contains the following applications:
 - **App4.RabbitConsumer.HostedService** is a **NET 7 Worker Service**.
   - A Hosted Service reads the messages from the Rabbitmq _"sample_2"_ queue and stores it into a Redis cache database.
 
-# OpenTelemetry .NET Client
+# **OpenTelemetry .NET Client**
 
 The apps are using the following package versions:
 
@@ -35,7 +35,7 @@ The apps are using the following package versions:
   <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.10" />
 ```
 
-# External Dependencies
+# **External Dependencies**
 
 - Jaeger 
 - MSSQL Server
@@ -43,16 +43,20 @@ The apps are using the following package versions:
 - Redis Cache
 
 
-# How to run the apps
+# **How to run the apps**
+
+##  **Using docker-compose**
 
 The repository contains  a **docker-compose** file that starts up the 4 apps and also the external dependencies.   
 There is a **little caveat in the docker-compose**: 
 - You can control the order of service startup and shutdown with the depends_on option. However, for startup Compose does not wait until a container is “ready” only until it’s running.    
 That's a problem because both App3 and App4 need to wait for the rabbitMq container to be ready. To avoid this problem the docker-compose is overwriting the "entrypoint" for both apps and executing a shell script that makes both apps sleep 30 seconds before starting up.
 
-If you **don't want to use the docker-compose file**, you can use docker to start the dependencies manually, you can ran the following commands:
+## **Without using the docker-compose**
 
-- Run the Jaeger image:
+If you **don't want to use the docker-compose file**, you can use docker to start the dependencies one by one.
+
+- Run a Jaeger image:
 ```shell
 docker run -d --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
@@ -96,13 +100,13 @@ docker run -d --name some-redis \
 
 # Output
 
-If you open jaeger you are going to see something like this
+If you open Jaeger, you are going to see something like this
 
 ![Alt Text](https://github.com/karlospn/opentelemetry-tracing-demo/blob/master/docs/jaeger.png)
 
 # Changelog
 
-### **09/23/2023**
+### **09/24/2023**
 - Update apps to .NET 7.
 - Update OpenTelemetry packages to the latest version.
 - Fix breaking changes on the apps due to the OpenTeleetry packages version upgrade.

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ The repository contains the following applications:
 
 ![Alt Text](https://github.com/karlospn/opentelemetry-tracing-demo/blob/master/docs/components-diagram.png)
 
-- **App1.WebApi** is a **NET7 Web API** with 2 endpoints.
+- **App1.WebApi** is a **NET 7 Web API** with 2 endpoints.
     - The **/http** endpoint makes an HTTP request to the App2 _"/dummy"_ endpoint.
     - The **/publish-message** endpoint queues a message into a Rabbit queue named _"sample"_.
     
-- **App2.RabbitConsumer.Console** is a **NET7 console** application. 
+- **App2.RabbitConsumer.Console** is a **NET 7 console** application. 
   - Dequeues messages from the Rabbit _"sample"_ queue and makes a HTTP request to the **App3** _"/sql-to-event"_ endpoint with the content of the message.
 
-- **App3.WebApi** is a **NET7 Web API** with 2 endpoints
+- **App3.WebApi** is a **NET 7 Web API** with 2 endpoints
     - The **/dummy** endpoint returns a fixed _"Ok"_ response.
     - The **/sql-to-event** endpoint receives a message via HTTP POST, stores it in a MSSQL Server and afterwards publishes the message as an event into a RabbitMq queue named _"sample_2"_.
 
-- **App4.RabbitConsumer.HostedService** is a **NET7 Worker Service**.
+- **App4.RabbitConsumer.HostedService** is a **NET 7 Worker Service**.
   - A Hosted Service reads the messages from the Rabbitmq _"sample_2"_ queue and stores it into a Redis cache database.
 
 # OpenTelemetry .NET Client
@@ -50,10 +50,9 @@ There is a **little caveat in the docker-compose**:
 - You can control the order of service startup and shutdown with the depends_on option. However, for startup Compose does not wait until a container is “ready” only until it’s running.    
 That's a problem because both App3 and App4 need to wait for the rabbitMq container to be ready. To avoid this problem the docker-compose is overwriting the "entrypoint" for both apps and executing a shell script that makes both apps sleep 30 seconds before starting up.
 
-
 If you **don't want to use the docker-compose file**, you can use docker to start the dependencies manually, you can ran the following commands:
 
-- Run jaeger image:
+- Run the Jaeger image:
 ```shell
 docker run -d --name jaeger \
   -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
@@ -70,32 +69,30 @@ docker run -d --name jaeger \
   -p 9411:9411 \
   jaegertracing/all-in-one:latest
 ```
-
-- Run rabbitmq image:
+- Run a Rabbitmq image:
 
 ```shell
 docker run -d --name some-rabbit \
   -p 15672:15672 \
   -p 5672:5672 \
   rabbitmq:3.12-management
-````
-- Run MSSQL Server
+```
+- Run a MSSQL Server
 
 ```shell
 docker run -e "ACCEPT_EULA=Y" \
   -e "SA_PASSWORD=Pass@Word1" \
   -p 1433:1433 \
   -d mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04
-````
+```
 
-- Run Redis
+- Run a Redis immage:
 
 ```shell
 docker run -d --name some-redis \
   -p "6379:6379" \
   redis:7.2.1
-````
-
+```
 
 # Output
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
     
 services:
   rabbitmq:
-    image: rabbitmq:3.6.15-management
+    image: rabbitmq:3.12-management
     ports:
       - 15672:15672
       - 5672
@@ -24,7 +24,7 @@ services:
       - tracing
 
   redis:
-    image: redis:6.2.1
+    image: redis:7.2.1
     ports:
     - 6379:6379
     networks:
@@ -36,14 +36,20 @@ services:
     restart: unless-stopped
     ports:
       - 5775:5775/udp
-      - 5778:5778
       - 6831:6831/udp
       - 6832:6832/udp
-      - 9411:9411
-      - 14268:14268
+      - 5778:5778
       - 16686:16686
+      - 14250:14250
+      - 14268:14268
+      - 14269:14269
+      - 4317:4317
+      - 4318:4318
+      - 9411:9411
     networks:
       - tracing
+    environment:
+      COLLECTOR_OTLP_ENABLED: true
 
   app1:
     build:
@@ -57,8 +63,9 @@ services:
       - jaeger
       - app3
     environment:
-      Jaeger__AgentHost: jaeger
-      Jaeger__AgentPort: 6831
+      Jaeger__Protocol: http
+      Jaeger__Port: 4317
+      Jaeger__Host: jaeger
       RabbitMq__Host: rabbitmq
       App3Endpoint: http://app3/dummy
 
@@ -75,8 +82,9 @@ services:
       - app3
     entrypoint: ["./wait.sh", "30", "dotnet", "App2.RabbitConsumer.Console.dll"]
     environment:
-      Jaeger__AgentHost: jaeger
-      Jaeger__AgentPort: 6831
+      Jaeger__Protocol: http
+      Jaeger__Port: 4317
+      Jaeger__Host: jaeger
       RabbitMq__Host: rabbitmq
       App3UriEndpoint: http://app3
 
@@ -93,8 +101,9 @@ services:
       - jaeger
       - sqlserver
     environment:
-      Jaeger__AgentHost: jaeger
-      Jaeger__AgentPort: 6831
+      Jaeger__Protocol: http
+      Jaeger__Port: 4317
+      Jaeger__Host: jaeger
       RabbitMq__Host: rabbitmq
       SqlDbConnString: server=sqlserver;user id=sa;password=Pass@Word1;
   
@@ -111,8 +120,9 @@ services:
       - redis
     entrypoint: ["./wait.sh", "30", "dotnet", "App4.RabbitConsumer.HostedService.dll"]
     environment:
-      Jaeger__AgentHost: jaeger
-      Jaeger__AgentPort: 6831
+      Jaeger__Protocol: http
+      Jaeger__Port: 4317
+      Jaeger__Host: jaeger
       RabbitMq__Host: rabbitmq
       Redis__Host: redis
       Redis__Port: 6379


### PR DESCRIPTION
- Update apps to .NET 7.
- Update OpenTelemetry packages to the latest version.
- Fix breaking changes on the apps due to the OpenTeleetry packages version upgrade.
- Removed the ``OpenTelemetry.Exporter.Jaeger`` NuGet package from the apps because it has been deprecated. It has been replaced by the ``OpenTelemetry.Exporter.OpenTelemetryProtocol`` package.
- Update the ``RabbitMQ.Client`` NuGet package to the latest version.
- Update the ``dockerfile-compose`` file to use the newest image versions of rabbitmq, redis and jaeger. Also the jaeger image is configured so can it can receive OpenTelemetry trace data via the OpenTelemetry Protocol.